### PR TITLE
Update requirements.txt for Python 3.13 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-Pillow==9.5.0; python_version >= '3.8'
+Pillow>=11.0.0; python_version >= '3.13'
+Pillow>=9.5.0; python_version >= '3.8' and python_version < '3.13'
 Pillow==9.0.1; python_version == '3.7'
 Pillow==8.4.0; python_version == '3.6'
 urllib3==1.26.7


### PR DESCRIPTION
Pillow 9.5.0 doesn't support Python 3.13, throwing this error. This fixes the support.

Defaulting to user installation because normal site-packages is not writeable
Ignoring Pillow: markers 'python_version == "3.7"' don't match your environment
Ignoring Pillow: markers 'python_version == "3.6"' don't match your environment
Collecting Pillow==9.5.0 (from -r requirements.txt (line 1))
  Downloading Pillow-9.5.0.tar.gz (50.5 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 50.5/50.5 MB 11.8 MB/s eta 0:00:00
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [24 lines of output]
      Traceback (most recent call last):
        File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.13_3.13.496.0_x64qbz5n2kfra8p0\Lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 353, in <module>
          main()
          ~~~~^^
        File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.13_3.13.496.0_x64qbz5n2kfra8p0\Lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
                                   ~~~~^^^^^^^^^^^^^^^^^^^^^^^^
        File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.13_3.13.496.0_x64qbz5n2kfra8p0\Lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
        File "C:\Users\leand\AppData\Local\Temp\pip-build-env-gvt6a2b6\overlay\Lib\site-packages\setuptools\build_meta.py", line 334, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "C:\Users\leand\AppData\Local\Temp\pip-build-env-gvt6a2b6\overlay\Lib\site-packages\setuptools\build_meta.py", line 304, in getbuild_requires
          self.run_setup()
          ~~~~~~~~~~~~~~^^
        File "C:\Users\leand\AppData\Local\Temp\pip-build-env-gvt6a2b6\overlay\Lib\site-packages\setuptools\build_meta.py", line 522, in run_setup
          super().run_setup(setup_script=setup_script)
          ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "C:\Users\leand\AppData\Local\Temp\pip-build-env-gvt6a2b6\overlay\Lib\site-packages\setuptools\build_meta.py", line 320, in run_setup
          exec(code, locals())
          ~~~~^^^^^^^^^^^^^^^^
        File "<string>", line 29, in <module>
        File "<string>", line 26, in get_version
      KeyError: 'version__'
      [end of output]
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error
× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.
note: This error originates from a subprocess, and is likely not a problem with pip.